### PR TITLE
Updates:

### DIFF
--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.8.4
-MAVEN_SHA=2cdc9c519427bb20fdc25bef5a9063b790e4abd930e7b14b4e9f4863d6f9f13c
+MAVEN_VERSION=3.8.6
+MAVEN_SHA=c7047a48deb626abf26f71ab3643d296db9b1e67f1faa7d988637deac876b5a9
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/install-zulu11.sh
+++ b/.github/install-zulu11.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=11
-ZULU_RELEASE=11.0.13-1
+ZULU_RELEASE=11.0.15-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/install-zulu8.sh
+++ b/.github/install-zulu8.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=8
-ZULU_RELEASE=8.0.312-1
+ZULU_RELEASE=8.0.332-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         java_version: [8, 11]
-        maven_version: [3.8.4]
+        maven_version: [3.8.6]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             java_version: 11
-            maven_version: 3.8.4
+            maven_version: 3.8.6
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.4_openjdk-11.0.13_zulu-alpine-11.52.13
+        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.15_zulu-alpine-11.56.19
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.4_openjdk-11.0.13_zulu-alpine-11.52.13
+            image: luminositylabs/maven:3.8.6_openjdk-11.0.15_zulu-alpine-11.56.19
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -13,6 +13,13 @@
             </ignoreVersions>
         </rule>
 
+        <!-- Pin checkstyle version to pre-V10 -->
+        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">10\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>

--- a/pmd.xml
+++ b/pmd.xml
@@ -16,6 +16,7 @@
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+    <rule ref="category/java/codestyle.xml/EmptyControlStatement"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
     <rule ref="category/java/codestyle.xml/TooManyStaticImports"/>
@@ -37,15 +38,7 @@
     <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray"/>
     <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
     <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
-    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
     <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
-    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
-    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyWhileStmt"/>
     <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
     <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
     <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2016-2021 Luminosity Labs LLC. All rights reserved.
+ Copyright (c) 2016-2022 Luminosity Labs LLC. All rights reserved.
 
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with this
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-orientdb-utils</artifactId>


### PR DESCRIPTION
- copyright update from 2021 to 2022
- github actions workflow os updated from ubuntu-20.04 to ubuntu-22.04
- CI maven updated from v3.8.4 to v3.8.6
- CI zulu-8 updated from v8.0.312-1 to v8.0.332-1
- CI zulu-11 updated from v11.0.13-1 to v11.0.15-1
- luminositylabs-oss-parent updated from v0.2.3-SNAPSHOT to v0.2.6-SNAPSHOT
- update ignore rules for checkstype v10 in maven-version-rules.xml
- remove deprecated errorprone PMD rules